### PR TITLE
fix: glob patterns should always use `/`

### DIFF
--- a/exercises/01.e2e/01.problem.init/other/build-server.ts
+++ b/exercises/01.e2e/01.problem.init/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/01.solution.init/other/build-server.ts
+++ b/exercises/01.e2e/01.solution.init/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/02.problem.mocks/other/build-server.ts
+++ b/exercises/01.e2e/02.problem.mocks/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/02.solution.mocks/other/build-server.ts
+++ b/exercises/01.e2e/02.solution.mocks/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/03.problem.fixtures/other/build-server.ts
+++ b/exercises/01.e2e/03.problem.fixtures/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/03.solution.fixtures/other/build-server.ts
+++ b/exercises/01.e2e/03.solution.fixtures/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/04.problem.cleanup/other/build-server.ts
+++ b/exercises/01.e2e/04.problem.cleanup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/01.e2e/04.solution.cleanup/other/build-server.ts
+++ b/exercises/01.e2e/04.solution.cleanup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/01.problem.insert-user/other/build-server.ts
+++ b/exercises/02.e2e-auth/01.problem.insert-user/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/01.solution.insert-user/other/build-server.ts
+++ b/exercises/02.e2e-auth/01.solution.insert-user/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/02.problem.cleanup/other/build-server.ts
+++ b/exercises/02.e2e-auth/02.problem.cleanup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/02.solution.cleanup/other/build-server.ts
+++ b/exercises/02.e2e-auth/02.solution.cleanup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/03.problem.login-page/other/build-server.ts
+++ b/exercises/02.e2e-auth/03.problem.login-page/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/03.solution.login-page/other/build-server.ts
+++ b/exercises/02.e2e-auth/03.solution.login-page/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/04.problem.login-util/other/build-server.ts
+++ b/exercises/02.e2e-auth/04.problem.login-util/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/02.e2e-auth/04.solution.login-util/other/build-server.ts
+++ b/exercises/02.e2e-auth/04.solution.login-util/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/03.unit/01.problem.unit/other/build-server.ts
+++ b/exercises/03.unit/01.problem.unit/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/03.unit/01.solution.unit/other/build-server.ts
+++ b/exercises/03.unit/01.solution.unit/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/03.unit/02.problem.isolation/other/build-server.ts
+++ b/exercises/03.unit/02.problem.isolation/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/03.unit/02.solution.isolation/other/build-server.ts
+++ b/exercises/03.unit/02.solution.isolation/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/04.component/01.problem.initial-test/other/build-server.ts
+++ b/exercises/04.component/01.problem.initial-test/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/04.component/01.solution.initial-test/other/build-server.ts
+++ b/exercises/04.component/01.solution.initial-test/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/04.component/02.problem.setup/other/build-server.ts
+++ b/exercises/04.component/02.problem.setup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/04.component/02.solution.setup/other/build-server.ts
+++ b/exercises/04.component/02.solution.setup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/01.problem.isolated/other/build-server.ts
+++ b/exercises/05.test-db/01.problem.isolated/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/01.solution.isolated/other/build-server.ts
+++ b/exercises/05.test-db/01.solution.isolated/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/02.problem.setup-env/other/build-server.ts
+++ b/exercises/05.test-db/02.problem.setup-env/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/02.solution.setup-env/other/build-server.ts
+++ b/exercises/05.test-db/02.solution.setup-env/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/03.problem.delete-data/other/build-server.ts
+++ b/exercises/05.test-db/03.problem.delete-data/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/03.solution.delete-data/other/build-server.ts
+++ b/exercises/05.test-db/03.solution.delete-data/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/04.problem.setup-env-vars/other/build-server.ts
+++ b/exercises/05.test-db/04.problem.setup-env-vars/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/04.solution.setup-env-vars/other/build-server.ts
+++ b/exercises/05.test-db/04.solution.setup-env-vars/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/05.problem.global-setup/other/build-server.ts
+++ b/exercises/05.test-db/05.problem.global-setup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],

--- a/exercises/05.test-db/05.solution.global-setup/other/build-server.ts
+++ b/exercises/05.test-db/05.solution.global-setup/other/build-server.ts
@@ -3,7 +3,8 @@ import path from 'path'
 import glob from 'glob'
 import pkg from '../package.json'
 
-const here = (...s: Array<string>) => path.join(__dirname, ...s)
+const here = (...s: Array<string>) =>
+	path.join(__dirname, ...s).replace(/\\/g, '/')
 
 const allFiles = glob.sync(here('../server/**/*.*'), {
 	ignore: ['**/tsconfig.json', '**/eslint*', '**/__tests__/**'],


### PR DESCRIPTION
on windows this call to `glob.sync` return an epmy array
`entryPoints: glob.sync(here('../server/**/*.+(ts|js|tsx|jsx)')),`

from [Glob docs](https://www.npmjs.com/package/glob) - `Note Glob patterns should always use / as a path separator, even on Windows systems, as \ is used to escape glob characters`

without this fix app build fails
```
Error: Cannot find module './server-build'
Require stack:
- C:\projects\kcd-apps\testing-web-apps\playground\index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (C:\projects\kcd-apps\testing-web-apps\playground\index.js:4:2)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ 'C:\\projects\\kcd-apps\\testing-web-apps\\playground\\index.js' ]
}
```